### PR TITLE
Fix for updating subscriptions

### DIFF
--- a/internal/stubs/subscriptions.go
+++ b/internal/stubs/subscriptions.go
@@ -82,32 +82,40 @@ func SubscriptionGetResponse() []byte {
 func SubscriptionUpdateResponse() []byte {
 	return []byte(`
 {
-  "type": "subscriptions",
-  "id": "1",
-  "attributes": {
-    "store_id": 1,
-    "order_id": 1,
-    "order_item_id": 1,
-    "product_id": 9,
-    "variant_id": 11,
-    "product_name": "New Plan Product",
-    "variant_name": "New Plan Variant",
-    "user_name": "Darlene Daugherty",
-    "user_email": "gernser@yahoo.com",
-    "status": "active",
-    "status_formatted": "Active",
-    "pause": null,
-    "cancelled": false,
-    "trial_ends_at": null,
-    "billing_anchor": 29,
-    "urls": {
-      "update_payment_method": "https://app.lemonsqueezy.com/my-orders/2ba92a4e-a00a-45d2-a128-16856ffa8cdf/subscription/8/update-payment-method?expires=1666869343&signature=9985e3bf9007840aeb3951412be475abc17439c449c1af3e56e08e45e1345413"
-    },
-    "renews_at": "2022-11-12T00:00:00.000000Z",
-    "ends_at": null,
-    "created_at": "2021-08-11T13:47:27.000000Z",
-    "updated_at": "2021-08-11T13:54:19.000000Z",
-    "test_mode": false
+  "jsonapi":{
+    "version":"1.0"
+  },
+  "links":{
+    "self":"https://api.lemonsqueezy.com/v1/subscriptions/1"
+  },
+  "data": {
+    "type": "subscriptions",
+    "id": "1",
+    "attributes": {
+      "store_id": 1,
+      "order_id": 1,
+      "order_item_id": 1,
+      "product_id": 9,
+      "variant_id": 11,
+      "product_name": "New Plan Product",
+      "variant_name": "New Plan Variant",
+      "user_name": "Darlene Daugherty",
+      "user_email": "gernser@yahoo.com",
+      "status": "active",
+      "status_formatted": "Active",
+      "pause": null,
+      "cancelled": false,
+      "trial_ends_at": null,
+      "billing_anchor": 29,
+      "urls": {
+        "update_payment_method": "https://app.lemonsqueezy.com/my-orders/2ba92a4e-a00a-45d2-a128-16856ffa8cdf/subscription/8/update-payment-method?expires=1666869343&signature=9985e3bf9007840aeb3951412be475abc17439c449c1af3e56e08e45e1345413"
+      },
+      "renews_at": "2022-11-12T00:00:00.000000Z",
+      "ends_at": null,
+      "created_at": "2021-08-11T13:47:27.000000Z",
+      "updated_at": "2021-08-11T13:54:19.000000Z",
+      "test_mode": false
+    }
   }
 }
 `)

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -41,19 +41,20 @@ type SubscriptionPause struct {
 
 // SubscriptionUpdateParams are parameters for updating a subscription
 type SubscriptionUpdateParams struct {
-	Type               string                             `json:"type"`
-	ID                 string                             `json:"id"`
-	Pause              *SubscriptionPause                 `json:"pause,omitempty"`
-	Cancelled          bool                               `json:"cancelled,omitempty"`
-	InvoiceImmediately bool                               `json:"invoice_immediately,omitempty"`
-	Attributes         SubscriptionUpdateParamsAttributes `json:"attributes"`
+	Type       string                             `json:"type"`
+	ID         string                             `json:"id"`
+	Attributes SubscriptionUpdateParamsAttributes `json:"attributes"`
 }
 
 // SubscriptionUpdateParamsAttributes are subscription update attributes
 type SubscriptionUpdateParamsAttributes struct {
-	ProductID     int `json:"product_id"`
-	VariantID     int `json:"variant_id"`
-	BillingAnchor int `json:"billing_anchor"`
+	ProductID          int                `json:"product_id,omitempty"`
+	VariantID          int                `json:"variant_id,omitempty"`
+	BillingAnchor      int                `json:"billing_anchor,omitempty"`
+	Cancelled          bool               `json:"cancelled"`
+	Pause              *SubscriptionPause `json:"pause,omitempty"`
+	InvoiceImmediately bool               `json:"invoice_immediately"`
+	DisableProrations  bool               `json:"disable_prorations"`
 }
 
 // ApiResponseRelationshipsSubscription relationships of a subscription object

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -12,13 +12,25 @@ type SubscriptionsService service
 // Update an existing subscription to specific parameter
 //
 // https://docs.lemonsqueezy.com/api/subscriptions#update-a-subscription
-func (service *SubscriptionsService) Update(ctx context.Context, params *SubscriptionUpdateParams) (*Resource[Subscription], *Response, error) {
-	response, err := service.client.do(ctx, http.MethodPatch, "/v1/subscriptions/"+params.ID, params)
+func (service *SubscriptionsService) Update(ctx context.Context, params *SubscriptionUpdateParams) (*ApiResponseSubscription, *Response, error) {
+	typeParam := "subscriptions"
+	if len(params.Type) > 0 {
+		typeParam = params.Type
+	}
+	payload := map[string]any{
+		"data": map[string]any{
+			"id":         params.ID,
+			"type":       typeParam,
+			"attributes": params.Attributes,
+		},
+	}
+
+	response, err := service.client.do(ctx, http.MethodPatch, "/v1/subscriptions/"+params.ID, payload)
 	if err != nil {
 		return nil, response, err
 	}
 
-	subscription := new(Resource[Subscription])
+	subscription := new(ApiResponseSubscription)
 	if err = json.Unmarshal(*response.Body, subscription); err != nil {
 		return nil, response, err
 	}

--- a/subscriptions_service_test.go
+++ b/subscriptions_service_test.go
@@ -266,7 +266,7 @@ func TestSubscriptionsService_Update(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, response.HTTPResponse.StatusCode)
 	assert.Equal(t, stubs.SubscriptionUpdateResponse(), *response.Body)
-	assert.Equal(t, "1", subscription.ID)
+	assert.Equal(t, "1", subscription.Data.ID)
 
 	// Teardown
 	server.Close()


### PR DESCRIPTION
This PR fixes issue #9 where trying to update a subscription would throw the following error:

```json
{
  "jsonapi" : {
    "version" : "1.0"
  },
  "errors" : [
    {
      "status" : "400",
      "detail" : "The member data is required.",
      "source" : {
        "pointer" : "\/"
      },
      "title" : "Non-Compliant JSON:API Document"
    }
  ]
}
```

NOTE: This PR also changes the response type of the `SubscriptionsService.Update` function to be consistent with the rest of the SubscriptionService functions.