### PR TITLE
Add missing field in customer attributes

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -4,22 +4,25 @@ import "time"
 
 // CustomerAttributes are the attributes of a lemonsqueezy customer
 type CustomerAttributes struct {
-	StoreID                       int       `json:"store_id"`
-	Name                          string    `json:"name"`
-	Email                         string    `json:"email"`
-	Status                        string    `json:"status"`
-	City                          *string   `json:"city"`
-	Region                        *string   `json:"region"`
-	Country                       string    `json:"country"`
-	TotalRevenueCurrency          int       `json:"total_revenue_currency"`
-	Mrr                           int       `json:"mrr"`
-	StatusFormatted               string    `json:"status_formatted"`
-	CountryFormatted              string    `json:"country_formatted"`
-	TotalRevenueCurrencyFormatted string    `json:"total_revenue_currency_formatted"`
-	MrrFormatted                  string    `json:"mrr_formatted"`
-	CreatedAt                     time.Time `json:"created_at"`
-	UpdatedAt                     time.Time `json:"updated_at"`
-	TestMode                      bool      `json:"test_mode"`
+	StoreID                       int     `json:"store_id"`
+	Name                          string  `json:"name"`
+	Email                         string  `json:"email"`
+	Status                        string  `json:"status"`
+	City                          *string `json:"city"`
+	Region                        *string `json:"region"`
+	Country                       string  `json:"country"`
+	TotalRevenueCurrency          int     `json:"total_revenue_currency"`
+	Mrr                           int     `json:"mrr"`
+	StatusFormatted               string  `json:"status_formatted"`
+	CountryFormatted              string  `json:"country_formatted"`
+	TotalRevenueCurrencyFormatted string  `json:"total_revenue_currency_formatted"`
+	MrrFormatted                  string  `json:"mrr_formatted"`
+	Urls                          struct {
+		CustomerPortal string `json:"customer_portal"`
+	} `json:"urls"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	TestMode  bool      `json:"test_mode"`
 }
 
 // ApiResponseRelationshipsCustomer relationships of a customer


### PR DESCRIPTION
Adding the field 'urls' in CustomerAttributes, according to the official documentation.

[https://docs.lemonsqueezy.com/api/customers#the-customer-object](https://docs.lemonsqueezy.com/api/customers#the-customer-object)

![Json screen](https://github.com/NdoleStudio/lemonsqueezy-go/assets/56627182/86ded4a0-fba4-4b11-9412-8ddb5e7a99a3)

Mapping this field into a "map[string]string" seemed to me to be the best option (shorter and more readable + only one field in the sub-object for the moment). If it's preferable, I can create another structure to parse the field "urls" returned by the lemonsqueezy API.