### PR TITLE
quick fix for broken Products.Get() api

### DIFF
--- a/product.go
+++ b/product.go
@@ -12,7 +12,7 @@ type ProductAttributes struct {
 	StatusFormatted string    `json:"status_formatted"`
 	ThumbURL        string    `json:"thumb_url"`
 	LargeThumbURL   string    `json:"large_thumb_url"`
-	Price           int       `json:"price"`
+	Price           string    `json:"price"`
 	PayWhatYouWant  bool      `json:"pay_what_you_want"`
 	FromPrice       *int      `json:"from_price"`
 	ToPrice         *int      `json:"to_price"`

--- a/product.go
+++ b/product.go
@@ -12,7 +12,7 @@ type ProductAttributes struct {
 	StatusFormatted string    `json:"status_formatted"`
 	ThumbURL        string    `json:"thumb_url"`
 	LargeThumbURL   string    `json:"large_thumb_url"`
-	Price           string    `json:"price"`
+	Price           any       `json:"price"`
 	PayWhatYouWant  bool      `json:"pay_what_you_want"`
 	FromPrice       *int      `json:"from_price"`
 	ToPrice         *int      `json:"to_price"`


### PR DESCRIPTION
It seems lemon is now returning Price as a string.. even though their documentation says it's an int. 

This might break again later when lemon realizes that they changed the data type ( assuming it's an accidental change )