### PR TITLE
Add SubscriptionID to Subscription struct

### DIFF
--- a/internal/stubs/subscriptions.go
+++ b/internal/stubs/subscriptions.go
@@ -15,6 +15,7 @@ func SubscriptionGetResponse() []byte {
     "id": "1",
     "attributes": {
       "store_id": 1,
+      "subscription_id": 1,
       "customer_id": 1,
       "order_id": 1,
       "order_item_id": 1,
@@ -387,6 +388,7 @@ func SubscriptionCancelResponse() []byte {
     "id": "1",
     "attributes": {
       "store_id": 1,
+      "subscription_id": 1,
       "customer_id": 1,
       "order_id": 1,
       "order_item_id": 1,

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -6,6 +6,7 @@ import "time"
 // https://docs.lemonsqueezy.com/api/subscriptions#the-subscription-object
 type Subscription struct {
 	StoreID               int                                `json:"store_id"`
+	SubscriptionID        int                                `json:"subscription_id"`
 	CustomerID            int                                `json:"customer_id"`
 	OrderID               int                                `json:"order_id"`
 	OrderItemID           int                                `json:"order_item_id"`

--- a/subscriptions_service_test.go
+++ b/subscriptions_service_test.go
@@ -40,6 +40,7 @@ func TestSubscriptionsService_Get(t *testing.T) {
 			ID:   "1",
 			Attributes: Subscription{
 				StoreID:         1,
+				SubscriptionID:  1,
 				CustomerID:      1,
 				OrderID:         1,
 				OrderItemID:     1,
@@ -186,6 +187,7 @@ func TestSubscriptionsService_Cancel(t *testing.T) {
 			ID:   "1",
 			Attributes: Subscription{
 				StoreID:         1,
+				SubscriptionID:  1,
 				CustomerID:      1,
 				OrderID:         1,
 				OrderItemID:     1,


### PR DESCRIPTION
The Lemonsqueezy api docs are not really clear, and maybe incomplete even. 

But there is a subscription_id key in the api response, which isnt included in the Subscription struct currently.